### PR TITLE
trigger-pull should append

### DIFF
--- a/src/open_append.c
+++ b/src/open_append.c
@@ -5,4 +5,4 @@
 #include "open.h"
 
 int open_append(const char *fn)
-{ return open(fn,O_WRONLY | O_NDELAY | O_APPEND | O_CREAT,0600); }
+{ return open(fn,O_WRONLY | O_NDELAY | O_APPEND); }

--- a/src/trigger-pull.c
+++ b/src/trigger-pull.c
@@ -20,7 +20,7 @@ int main(int argc,char * const *argv) {
   file = *++argv;
   if (!file) usage();
 
-  fd = open_write(file);
+  fd = open_append(file);
   if (fd == -1)
     strerr_die4sys(111,FATAL,"cannot open ",file,": ");
   if (ndelay_on(fd) == -1)


### PR DESCRIPTION
trigger-pull writes to files in write mode, it should write in append mode.  i have tested this with fifo's and it doesn't seem to make a difference at current, but on regular files (and potentially on fifes in future or other systems) this has the affect of overwriting the first byte over and over.
