### PR TITLE
Issues with Documentation Fixes

### DIFF
--- a/doc/trigger-listen.txt
+++ b/doc/trigger-listen.txt
@@ -2,7 +2,7 @@
 :doctype: manpage
 
 == NAME
-trigger-listen - listen to a fifo and run a command
+trigger-listen - listen to a fifo and execute a command
 
 == SYNOPSIS
 !!!!

--- a/doc/trigger-listen.txt
+++ b/doc/trigger-listen.txt
@@ -2,19 +2,22 @@
 :doctype: manpage
 
 == NAME
-trigger-listen - listen to a fifo and execute a command
+trigger-listen - listen to a fifo(7) and execute a command
+
 
 == SYNOPSIS
 !!!!
-trigger-listen [ -UdDqQv1 -c _limit_ -t _timeout_ -i _interval_ -g _gid_ -u _uid_ ] _path_ _prog_
++trigger-listen+ [ +-UdDqQv1+ +-c+ +_limit_+ +-t+ +_timeout_+ +-i+ +_interval_+ +-g+ +_gid_+ +-u+ +_uid_+ ] +_path_+ +_prog_+
 !!!!
 
+
 == DESCRIPTION
-The +trigger-listen+ program listens for input on the fifo +_path_+.  When
-it receives input +trigger-listen+ invokes +_prog_+ and continues to
-listen for input on +_path_+.  An external program pulls the trigger by
-writing a byte of data to +_path_+.  The +trigger-listen+ does not examine input
-data.
+The +trigger-listen+ program listens for input on the +fifo(7)+ +_path_+ using
++read(2)+.  When it receives input +trigger-listen+ invokes +_prog_+ and
+continues to listen for input on +_path_+.  An external program pulls the
+trigger by writing a byte of data to +_path_+.  The +trigger-listen+ program
+does not examine input data.
+
 
 == OPTIONS
 
@@ -22,12 +25,11 @@ data.
 +-q+::
 Quiet.  Do not print error messages.
 
-+-Q+:: 
++-Q+::
 Print error messages. (Default)
 
 +-v+::
 Verbose.  Print both status and error messages.
-
 
 === LISTENING OPTIONS
 +-1+::
@@ -40,32 +42,33 @@ trigger pull occurs while +_limit_+ copies are running,
 copies exits.
 
 +-t _timeout_+::
-Wait at most +_timeout_+ seconds for a trigger pull.  If
-+_timeout_+
+Wait at most +_timeout_+ seconds for a trigger pull.  If +_timeout_+
 seconds elapse without a trigger pull, then +trigger-listen+ pulls
-its own trigger.  The default value of +_timeout_+
-is +(unsigned int)~0+.
+its own trigger.  (Default: +(unsigned int)~0+)
 
 +-i _interval_+::
 Wait at least +_interval_+ seconds between executions of
-+_prog_+.  If
-it receives a trigger pull within +_interval_+ seconds of the last
-execution, +trigger-listen+ executes +_prog_+ when
-+_interval_+
-seconds have elapsed.  The default value of +_interval_+ is 0.
++_prog_+.  If +trigger-listen+ receives a trigger pull within +_interval_+
+seconds of the last execution, +trigger-listen+ executes +_prog_+ when
++_interval_+ seconds have elapsed.  (Default: 0).
 
 +-g _gid_+::
-Switch group ID to +_gid_+ after preparing to receive trigger pulls.
+Set the effective group ID to +_gid_+ using +setgid(2)+ after preparing to
+receive trigger pulls.
 
 +-u _uid_+::
-Switch user ID to +_uid_+ after preparing to receive connections.
+Set the effective user ID to +_uid_+ using +setuid(2)+ after preparing to
+receive trigger pulls.
 
 +-U+::
-Same as +-g $GID -u $UID+.  Typically, +$GID+ and +$UID+ are
-set by http://cr.yp.to/daemontools/envuidgid.html[+envuidgid+].
+Set the effective user ID to the +environ(7)+ variable +_UID_+ and the
+effective group ID to the +environ(7)+ variable +_GID_+ after preparing to
+receive trigger pulls.  Same as +-g+ +_$GID_+ +-u+ +_$UID_+, where +_$UID_+
+and +_$GID_+ are typically set by
+http://cr.yp.to/daemontools/envuidgid.html[+envuidgid(8)+].
 
-+-d+:: 
-Delete.  Remove and recreate the fifo +_path_+ upon startup. (Default)
++-d+::
+Delete.  Remove and recreate the +fifo(7)+ +_path_+ upon startup. (Default)
 
 +-D+::
 No delete.  Do not remove and recreate +_path_+ upon startup.
@@ -73,12 +76,17 @@ No delete.  Do not remove and recreate +_path_+ upon startup.
 
 == EXIT STATUS
 The +trigger-listen+ program exits 111 for temporary errors and 100 for
-permanent errors.  It exits 0 on success or when terminated by signal.
+permanent errors.  +trigger-listen+ exits 0 on success or when terminated by
+signal.
 
 
 == EXAMPLES
 !!!!
-trigger-listen ./trigger echo \'Hello world!'
++trigger-listen+ ./trigger echo \'Hello world!'
 !!!!
 
 
+== SEE ALSO
++mkfifo(1)+, link:trigger-pull.html[+trigger-pull(1)+],
+link:trigger-wait.html[+trigger-wait(1)+], +setuid(2)+, +setgid(2)+,
++fifo(7)+, +envuidgid(8)+

--- a/doc/trigger-pull.txt
+++ b/doc/trigger-pull.txt
@@ -2,24 +2,26 @@
 :doctype: manpage
 
 == NAME
-trigger-pull - write a non-blocking byte to a fifo to pull a trigger
+trigger-pull - write a non-blocking byte to a fifo(7) to pull a trigger
 
 == SYNOPSIS
 !!!!
-trigger-pull _path_
++trigger-pull+ +_path_+
 !!!!
 
 == DESCRIPTION
-The +trigger-pull+ program performs a non-blocking write of one byte of data to
-+_path_+.
+The +trigger-pull+ program performs a non-blocking +write(2)+ of one byte of
+data to +_path_+.
 
 == EXIT STATUS
 The +trigger-pull+ program exits 100 for incorrect usage and 111 for temporary
-errors.  It does not retry if the write would have blocked and it ignores the
-lack of reader on the fifo +_path_+, treating these as successes.
-
+errors.  It does not retry if the +write(2)+ would have blocked and it ignores the
+lack of reader on the +fifo(7)+ +_path_+, treating these as successes.
 
 == EXAMPLES
 !!!!
 trigger-pull ./trigger
 !!!!
+
+== SEE ALSO
++mkfifo(1)+, +trigger-listen(1)+, +trigger-wait(1)+, +fifo(7)+

--- a/doc/trigger-pull.txt
+++ b/doc/trigger-pull.txt
@@ -24,4 +24,4 @@ trigger-pull ./trigger
 !!!!
 
 == SEE ALSO
-+mkfifo(1)+, +trigger-listen(1)+, +trigger-wait(1)+, +fifo(7)+
++mkfifo(1)+, link:trigger-listen.html[+trigger-listen(1)+], +trigger-wait(1)+, +fifo(7)+

--- a/doc/trigger-pull.txt
+++ b/doc/trigger-pull.txt
@@ -10,7 +10,7 @@ trigger-pull _path_
 !!!!
 
 == DESCRIPTION
-The +trigger-pull+ performs a non-blocking write of one byte of data to
+The +trigger-pull+ program performs a non-blocking write of one byte of data to
 +_path_+.
 
 == EXIT STATUS
@@ -23,6 +23,3 @@ lack of reader on the fifo +_path_+, treating these as successes.
 !!!!
 trigger-pull ./trigger
 !!!!
-
-
-

--- a/doc/trigger-wait.txt
+++ b/doc/trigger-wait.txt
@@ -2,7 +2,7 @@
 :doctype: manpage
 
 == NAME
-trigger-wait - listen to a trigger and optionally run a command
+trigger-wait - listen to a trigger and optionally execute a command
 
 == SYNOPSIS
 !!!!
@@ -11,15 +11,15 @@ trigger-wait [ -wWdD -t _timeout_ ] _path_ [ _prog_ ]
 
 
 == DESCRIPTION
-The +trigger-wait+ listens for input on the fifo +_path_+.  If +_prog_+ is
-present, +trigger-wait+ runs it and optionally waits for it to complete.  It
+The +trigger-wait+ program listens for input on the fifo +_path_+.  If +_prog_+ is
+present, +trigger-wait+ executes it and optionally waits for it to complete.  It
 then exits 0 if it received a trigger pull and 99 otherwise.
 
 
 === OPTIONS
 +-t _timeout_+::
 Wait at most +_timeout_+ seconds for a trigger pull.  If +_timeout_+
-seconds elapse without a trigger pull, then +trigger-listen+ pulls
+seconds elapse without a trigger pull, then +trigger-wait+ pulls
 its own trigger.  The default value of +_timeout_+
 is +(unsigned int)~0+.
 

--- a/doc/trigger-wait.txt
+++ b/doc/trigger-wait.txt
@@ -2,50 +2,53 @@
 :doctype: manpage
 
 == NAME
-trigger-wait - listen to a trigger and optionally execute a command
+trigger-wait - listen to a fifo(7) and optionally execute a command
 
 == SYNOPSIS
 !!!!
-trigger-wait [ -wWdD -t _timeout_ ] _path_ [ _prog_ ]
++trigger-wait+ [ +-wWdD+ +-t+ _timeout_ ] _path_ [ _prog_ ]
 !!!!
 
 
 == DESCRIPTION
-The +trigger-wait+ program listens for input on the fifo +_path_+.  If +_prog_+ is
-present, +trigger-wait+ executes it and optionally waits for it to complete.  It
-then exits 0 if it received a trigger pull and 99 otherwise.
+The +trigger-wait+ program listens for input on the +fifo(7)+ +_path_+ using
++read(2)+.  If +_prog_+ is present, +trigger-wait+ executes +_prog_+ and
+optionally waits for it to complete.
 
 
 === OPTIONS
 +-t _timeout_+::
 Wait at most +_timeout_+ seconds for a trigger pull.  If +_timeout_+
 seconds elapse without a trigger pull, then +trigger-wait+ pulls
-its own trigger.  The default value of +_timeout_+
-is +(unsigned int)~0+.
+its own trigger.  (Default: +(unsigned int)~0+)
 
 +-w+::
-Wait for +_prog_+ to complete. (Default)
+Wait for +_prog_+ to complete before exit. (Default)
 
 +-W+::
-Do not wait for +_prog_+ to complete.
+Do not wait for +_prog_+ to complete before exit.
 
 +-d+::
-Delete.  Remove and recreate the fifo +_path_+ upon startup.  (Default)
+Delete.  Remove and recreate the +fifo(7)+ +_path_+ upon startup.  (Default)
 
 +-D+::
 No delete.  Do not remove and recreate +_path_+ upon startup.
 
 
 == EXIT STATUS
-The +trigger-wait+ program exits 100 for permanent
-errors and 111 for temporary errors.  It exits 0 if it received a trigger pull,
-and 99 otherwise.
+The +trigger-wait+ program exits 100 for permanent errors and 111 for
+temporary errors.  It exits 0 if it received a trigger pull, and 99 otherwise.
 
 
 == EXAMPLES
-Assume that the processor for +/service/foo/log+ pulls the trigger as its dying
-act:
+Assume that the processor for +_/service/foo/log_+ pulls the trigger as its
+dying act:
 !!!!
 cd /service/foo && trigger-wait -t 5 ./trigger-rotate svc -a log
 !!!!
 
+
+== SEE ALSO
++mkfifo(1)+, link:trigger-pull.html[+trigger-pull(1)+],
+link:trigger-listen.html[+trigger-listen(1)+], +fifo(7)+, +multilog(8)+,
++svc(8)+


### PR DESCRIPTION
Word program is forgotten a few times, run should be execute as it is more descriptive, and more correct, and one issue in the trigger-wait docs that refers to self as trigger-listen.
